### PR TITLE
Development database with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,10 @@
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+# RisQC Backend
 
-# Spring Boot boilerplate
- 
-Quick start for Spring Boot and Gradle.
+## Requirements
+* [Docker](https://www.docker.com/get-started) with compose
 
-[![Build Status](https://travis-ci.org/cristiangreco/spring-boot-boilerplate.svg?branch=master)](https://travis-ci.org/cristiangreco/spring-boot-boilerplate)
+## Setup
+For the time being, you will need to grab a pre-processed database and place it in the `db-dump` directory  
+The latest database dump can be grabbed [here](https://drive.google.com/file/d/1i-WBtBt1lQZejS5YClAxdPxeeun2ACNH/view?usp=sharing)
 
-## How to build
-
-Build with Gradle wrapper:
-
-```sh
-$ ./gradlew clean build
-```
-
-## How to run
-
-Run with Gradle wrapper:
-
-```sh
-$ ./gradlew bootRun
-```
-
-Or run it as an executable jar:
-
-```sh
-$ java -jar build/libs/spring-boot-boilerplate-0.1.0.jar
-```
-
-## Testing with Curl
-
-```sh
-$ curl http://localhost:8080/hello
-{"message":"Hello, World!"}
-```
+You can then start the database by running `docker-compose up -d`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: r00t
+      MYSQL_DATABASE: risqc
+    ports:
+      - 3306:3306
+    volumes:
+      - ./db-dump:/docker-entrypoint-initdb.d

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,9 @@
 spring.application.name=Risk
 spring.jackson.property-naming-strategy=SNAKE_CASE
 
-spring.datasource.url=jdbc:mysql://risqc.c6zbv12kxde9.us-east-1.rds.amazonaws.com/risqc
-spring.datasource.username=risqc
-spring.datasource.password=3GpCu&3auRVh
+spring.datasource.url=jdbc:mysql://127.0.0.1/risqc
+spring.datasource.username=root
+spring.datasource.password=r00t
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.spatial.dialect.mysql.MySQLSpatialDialect
 logging.level.org.hibernate.SQL=DEBUG


### PR DESCRIPTION
You can now easily launch a development database using docker !
Updated the readme with instructions on how to set up the database